### PR TITLE
#168234218 adding get all related sessions api

### DIFF
--- a/server/controllers/sessions.js
+++ b/server/controllers/sessions.js
@@ -39,7 +39,25 @@ class session {
     });
   }
 
-  
+  static getAll(req, res) {
+    const relatedSessions = [];
+
+    sessions.map((RelatedSession) => {
+      users.map((specUser) => {
+        if (specUser.email === req.user.email) {
+          if (specUser.id === RelatedSession.mentorId || specUser.email
+             === RelatedSession.menteeEmail) {
+            relatedSessions.push(RelatedSession);
+          }
+        }
+      });
+    });
+
+    return res.status(200).json({
+      success: 'true',
+      relatedSessions,
+    });
+  }
 }
 
 export default session;

--- a/server/test/session.js
+++ b/server/test/session.js
@@ -101,3 +101,75 @@ describe('POST </API/v1/sessions> a mentee should create a session', () => {
 
 });
 
+
+describe('GET </API/v1/sessions> should get all sessions', () => {
+  it('It should display all related sessions ', () => {
+    chai
+      .request(app)
+      .get('/API/v1/sessions')
+      .set('Authorization', `Bearer ${menteeToken}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('success').eql('true');
+        res.body.relatedSessions.should.be.a('array');
+        res.body.relatedSessions[0].id.should.be.a('number');
+        res.body.relatedSessions[0].mentorId.should.be.a('number');
+        res.body.relatedSessions[0].menteeId.should.be.a('number');
+        res.body.relatedSessions[0].should.have.property('questions');
+        res.body.relatedSessions[0].should.have.property('menteeEmail');
+        res.body.relatedSessions[0].should.have.property('status');
+      });
+  });
+
+  it('It should check is user allowed ', () => {
+    chai
+      .request(app)
+      .get('/API/v1/sessions')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.be.a('object');
+      });
+  });
+
+
+  it('it should verify if there is not athorization in header set', () => {
+    chai
+      .request(app)
+      .get('/API/v1/sessions')
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('error').eql('Please Set The Authorization Header!');
+
+      });
+  });
+
+  it('it should verify if there is not token in header', () => {
+    chai
+      .request(app)
+      .get('/API/v1/sessions')
+      .set('Authorization', 'Bearer')
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('error').eql('No token provided, Access Denied!');
+
+      });
+  });
+
+  it('it should verify if there is not token in header', () => {
+    chai
+      .request(app)
+      .get('/API/v1/sessions')
+      .set('Authorization', 'Bearer aaaaaaaaaaaa')
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('error').eql('You provided the invalid token!');
+
+      });
+  });
+});
+


### PR DESCRIPTION
#### What does this PR do?
enable mentee and mentor to get all related sessions
#### Description of Task to be completed?
*As a mentee or mentor, I want to get all sessions related to me*
 **Acceptance Criteria**
```
Given to logged in  mentee or mentor

When I will visit this URL API/v1/sessions  with GET method
Then I will get all session related to me

Dev Notes: mentee or mentor get related sessions
200 Ok
403 forbidden
401 unauthorized
```
#### How should this be manually tested?
After clone repository goes to the root of project open path into command run the npm install and once setup is done click npm test.

Using Postman to test all endpoints:
Key: Content-Type value: application/JSON
To test authentication, add this to the header: Bearer TOKEN
Test endpoints
GET request
visit: URL API/v1/sessions

#### What are the relevant pivotal tracker stories?
[#168234218](https://www.pivotaltracker.com/story/show/168234218)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/47531860/64076077-5dbd8780-ccc0-11e9-892f-0c556dda5f69.png)
