### PR TITLE
#168234220 adding accept or reject api

### DIFF
--- a/server/controllers/sessions.js
+++ b/server/controllers/sessions.js
@@ -58,6 +58,39 @@ class session {
       relatedSessions,
     });
   }
+
+  static acceptOrReject(req, res) {
+    const id = parseInt(req.params.sessionId, 10);
+    const decision = req.params.decision.toLowerCase();
+    let MySession = '';
+    let sessMessage = '';
+    let sessStatus = 0;
+    sessions.map((sessionToUpdate) => {
+      if (sessionToUpdate.id === id) {
+        MySession = sessionToUpdate;
+      }
+    });
+
+    if (!MySession) {
+      sessMessage = 'Session not found';
+      sessStatus = 404;
+    } else if (decision === 'accept') {
+      MySession.status = 'accepted';
+      sessMessage = 'Session accepted successfuly';
+      sessStatus = 200;
+    } else if (decision === 'reject') {
+      MySession.status = 'reject';
+      sessMessage = 'Session reject successfuly';
+      sessStatus = 200;
+    } else if ( decision !== 'accept' || decision !== 'reject' ) {
+      sessMessage = 'invalid decision';
+      sessStatus = 400;
+    } 
+    return res.status(sessStatus).send({
+      status: sessStatus,
+      message: sessMessage,
+    });
+  }
 }
 
 export default session;

--- a/server/test/session.js
+++ b/server/test/session.js
@@ -173,3 +173,77 @@ describe('GET </API/v1/sessions> should get all sessions', () => {
   });
 });
 
+
+describe('POST </API/v1/sessions> a mentor should make decision', () => {
+  it('It should accept a session ', () => {
+    chai
+      .request(app)
+      .patch('/API/v1/sessions/1/accept')
+      .set('Authorization', `Bearer ${mentorToken}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('message').eql('Session accepted successfuly');
+
+      });
+  });
+
+  it('It should reject a session', () => {
+    chai
+      .request(app)
+      .patch('/API/v1/sessions/1/reject')
+      .set('Authorization', `Bearer ${mentorToken}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('message').eql('Session reject successfuly');
+      });
+  });
+
+  it('It should check if a session to be accepted is available', () => {
+    chai
+      .request(app)
+      .patch('/API/v1/sessions/0/accept')
+      .set('Authorization', `Bearer ${mentorToken}`)
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('message').eql('Session not found');
+      });
+  });
+
+  it('It should check if a session to be rejected is available', () => {
+    chai
+      .request(app)
+      .patch('/API/v1/sessions/0/reject')
+      .set('Authorization', `Bearer ${mentorToken}`)
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('message').eql('Session not found');
+      });
+  });
+
+  it('It should check if a user allowed to do this action', () => {
+    chai
+      .request(app)
+      .patch('/API/v1/sessions/1/reject')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.be.a('object');
+      });
+  });
+
+  it('It should check if decision taken are valid', () => {
+    chai
+      .request(app)
+      .patch('/API/v1/sessions/1/dfghj')
+      .set('Authorization', `Bearer ${mentorToken}`)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.body.should.have.be.a('object');
+      });
+  });
+
+});


### PR DESCRIPTION
#### What does this PR do?
enable the mentor to accept or reject a session
#### Description of Task to be completed?
as a mentor, I want to accept or reject a session

*As a mentor I want to make a decision either to accept or to reject a session *
 **Acceptance Criteria**
```
Given a logged in mentor

When I visit this URL API/v1/sessions/:sessionId/:decision  with PATCH method
Then targeted session will be accepted or rejected according to a decision I will make
Dev Notes: mentor will accept or reject a session
200 Ok
401 unauthorized
```
#### How should this be manually tested?
After clone repository goes to the root of project open path into command run the npm install and once setup is done click npm test.

Using Postman to test all endpoints:
Key: Content-Type value: application/JSON
To test authentication, add this to the header: Bearer TOKEN
Test endpoints
PATCH request
visit: URL API/v1/sessions/:sessionId/:decision

#### What are the relevant pivotal tracker stories?
[#168234220](https://www.pivotaltracker.com/story/show/168234220)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/47531860/64076214-3e275e80-ccc2-11e9-81fa-152cbf4f4829.png)
