### PR TITLE
#168234238 adding get all reviewed sessions 

### DIFF
--- a/server/controllers/sessionReview.js
+++ b/server/controllers/sessionReview.js
@@ -53,7 +53,12 @@ class sessionReview {
     });
   }
 
-  
+  static allReview(req, res) {
+    return res.status(200).json({
+      success: 'true',
+      sessionReviews,
+    });
+  }
 }
 
 export default sessionReview;

--- a/server/test/sessionReview.js
+++ b/server/test/sessionReview.js
@@ -74,3 +74,38 @@ describe('it should check bad request', () => {
       });
   });
 });
+
+describe('GET </API/v1/sessions>  GET all sessions reviewed', () => {
+  it('It should display all reviewed sessions', () => {
+    chai
+      .request(app)
+      .get('/API/v1/reviewedsessions')
+      .set('Authorization', `Bearer ${admintoken}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.be.a('object');
+        res.body.should.have.property('success');
+        res.body.sessionReviews.should.be.a('array');
+        res.body.sessionReviews[0].id.should.be.a('number');
+        res.body.sessionReviews[0].sessionId.should.be.a('number');
+        res.body.sessionReviews[0].mentorId.should.be.a('number');
+        res.body.sessionReviews[0].menteeId.should.be.a('number');
+        res.body.sessionReviews[0].score.should.be.a('number');
+        res.body.sessionReviews[0].should.have.property('menteeFullName');
+        res.body.sessionReviews[0].should.have.property('remark');
+
+      });
+  });
+
+
+  it('It should check if a user allowed to do this action', () => {
+    chai
+      .request(app)
+      .get('/API/v1/reviewedsessions')
+      .set('Authorization', `Bearer ${menteeToken}`)
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.be.a('object');
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
enable admin and mentor to see all reviewed session
#### Description of Task to be completed?
*As a mentor or admin I want to see all reviews related to me and as an admin, I want to see all reviews *
 **Acceptance Criteria**
```
Given a logged in mentor or admin

When I visit this URL API/v1/reviewedsessions  with GET method
Then I will see all reviewed sessions related to me

Dev Notes: get all reviewed sessions
200 Ok
401 unauthorized
```
#### How should this be manually tested?
After clone repository goes to the root of project open path into command run the npm install and once setup is done click npm test.

Using Postman to test all endpoints:
Key: Content-Type value: application/JSON
To test authentication, add this to the header: Bearer TOKEN
Test endpoints
GET  request
visit: URL API/v1/reviewedsessions
#### What are the relevant pivotal tracker stories?
[#168234238](https://www.pivotaltracker.com/story/show/168234238)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/47531860/64076608-3e762880-ccc7-11e9-9563-d4eee12aa4d6.png)
