### PR TITLE
#168285455 add lfa feedback on api

### DIFF
--- a/server/controllers/sessionReview.js
+++ b/server/controllers/sessionReview.js
@@ -42,20 +42,21 @@ class sessionReview {
 
       sessionReviews.push(newReview);
       return res.status(201).send({
-        success: 'true',
+        status: '201',
         message: 'session review successfuly sent',
         newReview,
       });
     } 
     return res.status(404).send({
-      success: 'fail',
+      status: '404',
       message: 'session not found',
     });
   }
 
   static allReview(req, res) {
     return res.status(200).json({
-      success: 'true',
+      status: '200',
+      message: 'success',
       sessionReviews,
     });
   }
@@ -72,13 +73,14 @@ class sessionReview {
     });
     if (deleteResult) {
       return res.status(200).send({
-        success: 'true',
+        status: '200',
+        message: 'success',
         deleteResult,
       });
     } 
 
     return res.status(404).send({
-      success: 'false',
+      status: '404',
       message: 'session review not found',
     });
 

--- a/server/controllers/sessions.js
+++ b/server/controllers/sessions.js
@@ -6,10 +6,9 @@ import { sessionsSchema } from '../helpers/validation';
 import customize from '../helpers/customize';
 
 class session {
-  
   static createNew(req, res) {
     const session1 = req.body;
-
+    let errorMessage = '';
     const { error } = Joi.validate(session1, sessionsSchema);
     if (error) {
       return customize.validateError(req, res, error, 400);
@@ -17,24 +16,42 @@ class session {
     sessions.forEach((newSession) => {
       if (newSession.menteeEmail === req.user.email && newSession.questions
         === session1.questions) {
-        return res.status(400).json({
-          message: 'session already exists',
-        });
+        errorMessage = 'session already exists';
       }
     });
+    if (errorMessage) {
+      return res.status(400).json({
+        status: '400',
+        message: errorMessage,
+      });
+    }
 
+    let mentorEmail = '';
+    users.map((thisMentor) => {
+      if (thisMentor.id === req.body.mentorId && thisMentor.type === 'mentor') {
+        mentorEmail = thisMentor.email;
+      }
+    });
+    if (!mentorEmail) {
+      return res.status(404).send({
+        status: '404',
+        message: 'mentor not found',
+      });
+    }
     const newSession = {
       id: NewidGeneretor(sessions),
       mentorId: req.body.mentorId,
       menteeId: req.user.id,
       questions: req.body.questions,
       menteeEmail: req.user.email,
+      mentorEmail,
       status: 'pending',
 
     };
     sessions.push(newSession);
     return res.status(201).json({
-      success: 'true',
+      status: '201',
+      message: 'success',
       newSession,
     });
   }
@@ -54,7 +71,8 @@ class session {
     });
 
     return res.status(200).json({
-      success: 'true',
+      status: '200',
+      message: 'success',
       relatedSessions,
     });
   }

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -25,6 +25,7 @@ class User {
 
     if (message) {
       return res.status(401).json({
+        status: '201',
         message,
       });
     }
@@ -42,10 +43,23 @@ class User {
       type: 'mentee',
 
     };
+    const outPoutData = {
+      id: NewidGeneretor(users),
+      firstName: User.firstName,
+      lastName: User.lastName,
+      email: User.email,
+      address: User.address,
+      bio: User.bio,
+      occupation: User.occupation,
+      expertise: User.expertise,
+      type: User.type,
+    };
     users.push(User);
     return res.status(201).json({
+      status: '201',
+      message: 'user added',
       token,
-      User,
+      outPoutData,
     });
   }
 
@@ -61,22 +75,32 @@ class User {
     const userData = req.body;
     let token = '';
     users.map((user) => {
-      // eslint-disable-next-line max-len
       if (user.email === userData.email && hashpassword.compareSync(userData.password, user.password)) {
         token = getToken(email);
-        loggedInUser = user;
+        loggedInUser = {
+          id: user.id,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          address: user.address,
+          bio: user.bio,
+          occupation: user.occupation,
+          expertise: user.expertise,
+          type: user.type,
+        };
       }
     });
 
 
     if (!loggedInUser) {
       return res.status(404).send({
-        success: 'fail',
+        status: 404,
         message: 'User not found, Incorrect email or password',
       });
     }
     return res.status(200).send({
-      success: 'true',
+      status: '200',
+      message: 'login successfuly',
       token,
       loggedInUser,
     });
@@ -84,6 +108,8 @@ class User {
 
   static getUsers(req, res) {
     return res.status(200).json({
+      status: '200',
+      message: 'success',
       users,
     });
   }
@@ -98,17 +124,19 @@ class User {
     });
     if (!userGotten) {
       return res.status(404).json({
-        success: 'false',
+        status: '404',
         message: 'user not found',
       });
     }
     return res.status(200).send({
+      status: '200',
+      message: 'success',
       userGotten,
     });
   }
   
   static updateUser(req, res) {
-    const id = parseInt(req.params.userId);
+    const id = parseInt(req.params.userId,10);
     let newMentor;
     users.map((userToUpdate) => {
       if (userToUpdate.id === id) {
@@ -119,12 +147,12 @@ class User {
 
     if (!newMentor) {
       return res.status(404).send({
-        success: 'false',
+        status: '404',
         message: 'user not found',
       });
     }
     return res.status(201).send({
-      success: 'true',
+      status: '201',
       message: 'user upDate successfully',
       newMentor,
     });
@@ -138,7 +166,8 @@ class User {
       }
     });
     return res.status(200).json({
-      success: 'true',
+      status: '200',
+      message: 'success',
       allMentor,
     });
   }
@@ -153,11 +182,13 @@ class User {
     });
     if (!specMentor) {
       return res.status(404).send({
-        success: 'false',
+        status: '404',
         message: 'mentor not found',
       });
     }
     return res.status(200).send({
+      status: '200',
+      message: 'success',
       specMentor,
     });
   }

--- a/server/test/mockData/session.js
+++ b/server/test/mockData/session.js
@@ -1,6 +1,6 @@
 const sessions = [
   {
-    mentorId: 1,
+    mentorId: 3,
     questions: 'i need your help in psychlogy',
   },
   {
@@ -25,6 +25,10 @@ const sessions = [
     questions: 'i need your help in psychlogy',
     menteeEmail: 'yves4@gmail.com',
     status: 'pending',
+  },
+  {
+    mentorId: 0,
+    questions: 'i need your help in hhhh',
   },
 ];
 

--- a/server/test/session.js
+++ b/server/test/session.js
@@ -20,7 +20,7 @@ describe('POST </API/v1/sessions> a mentee should create a session', () => {
       .end((err, res) => {
         res.should.have.status(201);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('true');
+        res.body.should.have.property('status');
       });
   });
 
@@ -44,6 +44,18 @@ describe('POST </API/v1/sessions> a mentee should create a session', () => {
       .set('Authorization', `Bearer ${menteeToken}`)
       .end((err, res) => {
         res.should.have.status(400);
+        res.body.should.have.be.a('object');
+      });
+  });
+
+  it('It should sheck if a mentor exist', () => {
+    chai
+      .request(app)
+      .post('/API/v1/sessions')
+      .send(sessions[4])
+      .set('Authorization', `Bearer ${menteeToken}`)
+      .end((err, res) => {
+        res.should.have.status(404);
         res.body.should.have.be.a('object');
       });
   });
@@ -111,7 +123,7 @@ describe('GET </API/v1/sessions> should get all sessions', () => {
       .end((err, res) => {
         res.should.have.status(200);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('true');
+        res.body.should.have.property('status');
         res.body.relatedSessions.should.be.a('array');
         res.body.relatedSessions[0].id.should.be.a('number');
         res.body.relatedSessions[0].mentorId.should.be.a('number');

--- a/server/test/sessionReview.js
+++ b/server/test/sessionReview.js
@@ -21,7 +21,7 @@ describe('post </sessions/1/review>  mentee should be able to review a mentor af
       .end((err, res) => {
         res.should.have.status(201);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('true');
+        res.body.should.have.property('status');
         res.body.should.have.property('message').eql('session review successfuly sent');
         res.body.newReview.should.have.property('id');
         res.body.newReview.should.have.property('sessionId');
@@ -84,7 +84,7 @@ describe('GET </API/v1/sessions>  GET all sessions reviewed', () => {
       .end((err, res) => {
         res.should.have.status(200);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success');
+        res.body.should.have.property('status');
         res.body.sessionReviews.should.be.a('array');
         res.body.sessionReviews[0].id.should.be.a('number');
         res.body.sessionReviews[0].sessionId.should.be.a('number');
@@ -119,7 +119,7 @@ describe('GET </API/v1/sessions>  delete specific  reviewed review deemed as ina
       .end((err, res) => {
         res.should.have.status(200);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('true');
+        res.body.should.have.property('status');
         res.body.deleteResult.should.be.a('string').eql('session review deleted successfuly');
       });
   });
@@ -132,7 +132,7 @@ describe('GET </API/v1/sessions>  delete specific  reviewed review deemed as ina
       .end((err, res) => {
         res.should.have.status(404);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('false');
+        res.body.should.have.property('status');
         res.body.should.have.property('message').eql('session review not found');
       });
   });

--- a/server/test/users.js
+++ b/server/test/users.js
@@ -98,7 +98,7 @@ describe('GET </API/v1/mentor/1>  GET specific mentor', () => {
       .end((err, res) => {
         res.should.have.status(404);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('false');
+        res.body.should.have.property('status');
         res.body.should.have.property('message').eql('mentor not found');
       });
   });
@@ -134,7 +134,7 @@ describe('GET </API/v1/auth/>  GET specific user', () => {
       .end((err, res) => {
         res.should.have.status(404);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('false');
+        res.body.should.have.property('status');
         res.body.should.have.property('message').eql('user not found');
       });
   });
@@ -173,16 +173,15 @@ describe('POST </API/v1/auth/signup>', () => {
         res.should.have.status(201);
         res.body.should.have.be.a('object');
         res.body.should.have.property('token');
-        res.body.User.should.have.property('id');
-        res.body.User.should.have.property('firstName');
-        res.body.User.should.have.property('lastName');
-        res.body.User.should.have.property('email');
-        res.body.User.should.have.property('password');
-        res.body.User.should.have.property('address');
-        res.body.User.should.have.property('bio');
-        res.body.User.should.have.property('occupation');
-        res.body.User.should.have.property('expertise');
-        res.body.User.should.have.property('type').eql('mentee');
+        res.body.outPoutData.should.have.property('id');
+        res.body.outPoutData.should.have.property('firstName');
+        res.body.outPoutData.should.have.property('lastName');
+        res.body.outPoutData.should.have.property('email');
+        res.body.outPoutData.should.have.property('address');
+        res.body.outPoutData.should.have.property('bio');
+        res.body.outPoutData.should.have.property('occupation');
+        res.body.outPoutData.should.have.property('expertise');
+        res.body.outPoutData.should.have.property('type').eql('mentee');
       });
   });
 
@@ -196,7 +195,7 @@ describe('POST </API/v1/auth/signin>', () => {
       .send(login)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.have.property('success').eql('true');
+        res.body.should.have.property('status');
         res.body.should.have.property('token');
         res.body.should.have.property('loggedInUser');
 
@@ -221,7 +220,7 @@ describe('POST </API/v1/auth/signin>', () => {
       .send({ email: 'fake@gmail.com', password: 'invalid' })
       .end((err, res) => {
         res.should.have.status(404);
-        res.body.should.have.property('success').eql('fail');
+        res.body.should.have.property('status');
         res.body.should.have.property('message').eql('User not found, Incorrect email or password');
       });
   });
@@ -237,7 +236,7 @@ describe('GET </API/v1/user/1>  change user type to be mentor', () => {
       .end((err, res) => {
         res.should.have.status(201);
         res.body.should.have.be.a('object');
-        res.body.should.have.property('success').eql('true');
+        res.body.should.have.property('status');
         res.body.should.have.property('message').eql('user upDate successfully');
         res.body.newMentor.should.have.property('id');
         res.body.newMentor.should.have.property('firstName');


### PR DESCRIPTION
#### What does this PR do?
this pull request comes to make API have a good formatted outputs

#### Description of Task to be completed?

### API response should be in good format

*current API*
-  return data in bad format
- sign up and sign-in are returning user password 
- there is no mentor email returned after creating  a session

*what I am going to change*

- I am going to make all API return good formated data
- I am going to remove password on the response of sign-in and signup
- I am going to add mentor email  after creating  a session

*what I expect *

- a good formated return data
- not password appears on the sign in and sign up API response
- a mentor email to be appeared  on creating a session response

#### How should this be manually tested?
After clone repository goes to the root of project open path into command run the npm install and once setup is done click npm test.

Using Postman to test all endpoints:

* create session API*

Key: Content-Type value: application/JSON
To test authentication, add this to the header: Bearer TOKEN
Test endpoints
POST request
visit: URL API/v1/sessions

*sign in API*

Key: Content-Type value: application/JSON
Test endpoints
POST request
visit: URL API/v1/auth/signin

*sign up API*

Key: Content-Type value: application/JSON
Test endpoints
POST request
visit: URL API/v1/auth/signup

#### What are the relevant pivotal tracker stories?
[#168285455](https://www.pivotaltracker.com/story/show/168285455)
## Screenshots (if appropriate)
### create a mentor session api out put
![image](https://user-images.githubusercontent.com/47531860/64254334-78416c00-cf1f-11e9-81ed-3a2e62eb1de0.png)
### sign in api out put
![image](https://user-images.githubusercontent.com/47531860/64254422-a757dd80-cf1f-11e9-8dbe-aa0dce3f19ab.png)
### sign up api out put
![image](https://user-images.githubusercontent.com/47531860/64254579-f998fe80-cf1f-11e9-9364-1713f10d84cc.png)
